### PR TITLE
Replace full words instead of substring matches

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -512,8 +512,8 @@ class Compiler
         $prop = $this->properties[$varName];
 
         if ($prop->hasDefault()) {
-            $string = str_replace(
-                $varName,
+            $string = preg_replace(
+                '/\b('.$varName.')\b/',
                 $varName . '|default(' . $prop->getDefault() . ')',
                 $string
             );


### PR DESCRIPTION
In case a property exists on the component that is a substring of
another, the replacement strategy of `str_replace` is too radical, as it
will replace the substring as well.

Case in point:

```
<template>
  <span v-if="showIcon"> :-D </span>
</template>

<script>
    ...
    props: {
        show: {
            type: Boolean,
            default: false,
        },
    },
    computed() {
        showIcon() {
            return true;
        },
    },
    ...
</script>
```

This will lead to the following Twig syntax being output:

```
{% if show|default(false)Icon %}<span> :-D </span>{% endif %}
```

TODO: A unit-test for this case should be added, but, alas!, the time...