### PR TITLE
Bugfix/include with class

### DIFF
--- a/src/Utils/TwigBuilder.php
+++ b/src/Utils/TwigBuilder.php
@@ -125,8 +125,15 @@ class TwigBuilder
      */
     public function createIncludePartial(string $partialPath, array $variables = [])
     {
-        if (empty($variables)) {
-            return $this->createBlock('include "' . $partialPath . '"');
+        $hasClassProperty = false;
+        foreach ($variables as $variable) {
+            if ($variable->getName() === 'class') {
+                $hasClassProperty = true;
+            }
+        }
+
+        if (!$hasClassProperty) {
+            $variables[] = new Property('class', '""', false);
         }
 
         $serializedProperties = $this->serializeComponentProperties($variables);

--- a/tests/fixtures/vue-component/component-with-child-binding.twig
+++ b/tests/fixtures/vue-component/component-with-child-binding.twig
@@ -1,3 +1,3 @@
 <div class="{{class|default('')}}">
-  {% include "/templates/ChildComponent.twig" with { 'style': "fill:{{ color }};", 'test': "test" } %}
+  {% include "/templates/ChildComponent.twig" with { 'style': "fill:{{ color }};", 'test': "test", 'class': "" } %}
 </div>

--- a/tests/fixtures/vue-component/component-with-child.twig
+++ b/tests/fixtures/vue-component/component-with-child.twig
@@ -1,3 +1,3 @@
 <div class="{{class|default('')}}">
-  {% include "/templates/ChildComponent.twig" %}
+  {% include "/templates/ChildComponent.twig" with { 'class': "" } %}
 </div>

--- a/tests/fixtures/vue-component/component-with-for.twig
+++ b/tests/fixtures/vue-component/component-with-for.twig
@@ -1,3 +1,3 @@
 <div class="{{class|default('')}}">
-  {% for a in listOfProducts %}{% include "/templates/ChildComponent.twig" with { 'string': "string", 'product': productA } %}{% endfor %}
+  {% for a in listOfProducts %}{% include "/templates/ChildComponent.twig" with { 'string': "string", 'product': productA, 'class': "" } %}{% endfor %}
 </div>

--- a/tests/fixtures/vue-component/component-with-if.twig
+++ b/tests/fixtures/vue-component/component-with-if.twig
@@ -1,3 +1,3 @@
 <div class="{{class|default('')}}">
-  {% if a > 5 %}{% include "/templates/ChildComponent.twig" with { 'string': "string", 'product': productA } %}{% endif %}
+  {% if a > 5 %}{% include "/templates/ChildComponent.twig" with { 'string': "string", 'product': productA, 'class': "" } %}{% endif %}
 </div>

--- a/tests/fixtures/vue-component/component-with-inline-condition-prop.twig
+++ b/tests/fixtures/vue-component/component-with-inline-condition-prop.twig
@@ -2,5 +2,5 @@
   {% include "/templates/ChildComponent.twig" with {
     'product': testProduct,
     'showSomething': index > 5 and a == true,
-    'testA': "Hello", 'string': "Test" } %}
+    'testA': "Hello", 'string': "Test", 'class': "" } %}
 </div>

--- a/tests/fixtures/vue-component/component-with-prop.twig
+++ b/tests/fixtures/vue-component/component-with-prop.twig
@@ -1,3 +1,3 @@
 <div class="{{class|default('')}}">
-  {% include "/templates/ChildComponent.twig" with { 'product': testProduct, 'testA': "Hello", 'string': "Test" } %}
+  {% include "/templates/ChildComponent.twig" with { 'product': testProduct, 'testA': "Hello", 'string': "Test", 'class': "" } %}
 </div>

--- a/tests/fixtures/vue-slot/include-child-component-with-default-slot.twig
+++ b/tests/fixtures/vue-slot/include-child-component-with-default-slot.twig
@@ -3,5 +3,5 @@
     <h4>My default slot title</h4>
     <p>some text</p>
   {% endset %}
-  {% include "/templates/ChildComponent.twig" with { 'slot_default': slot_default_value } %}
+  {% include "/templates/ChildComponent.twig" with { 'slot_default': slot_default_value, 'class': "" } %}
 </div>


### PR DESCRIPTION
TWIG automatically passes variables downwards. This should be prevented with the class attribute by passing an empty value if nothing is specified.