### PR TITLE
Fix binding for all encoded attributes

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -406,10 +406,27 @@ class Compiler
                     Replacements::getSanitizedConstant('DOUBLE_CURLY_CLOSE');
             }
 
-            $node->setAttribute(
-                $name === 'src' ? Replacements::getSanitizedConstant('SRC_ATTRIBUTE_NAME') : $name,
-                $this->implodeAttributeValue($name, $dynamicValues, $staticValues)
-            );
+            /** @see https://gitlab.gnome.org/GNOME/libxml2/-/blob/LIBXML2.6.32/HTMLtree.c#L657 */
+            switch ($name) {
+                case 'href':
+                    $name = Replacements::getSanitizedConstant('ATTRIBUTE_NAME_HREF');
+                    break;
+                case 'action':
+                    $name = Replacements::getSanitizedConstant('ATTRIBUTE_NAME_ACTION');
+                    break;
+                case 'src':
+                    $name = Replacements::getSanitizedConstant('ATTRIBUTE_NAME_SRC');
+                    break;
+                case 'name':
+                    if ($node->tagName === 'a') {
+                        $name = Replacements::getSanitizedConstant('ATTRIBUTE_NAME_A_NAME');
+                    }
+                    break;
+                default:
+                    break;
+            }
+
+            $node->setAttribute($name, $this->implodeAttributeValue($name, $dynamicValues, $staticValues));
         }
     }
 

--- a/src/Models/Replacements.php
+++ b/src/Models/Replacements.php
@@ -12,7 +12,10 @@ abstract class Replacements extends BasicEnum
     public const SMALLER = '<';
     public const AMPERSAND = '&';
     public const PIPE = '|';
-    public const SRC_ATTRIBUTE_NAME = 'src';
+    public const ATTRIBUTE_NAME_HREF = 'href';
+    public const ATTRIBUTE_NAME_ACTION = 'action';
+    public const ATTRIBUTE_NAME_SRC = 'src';
+    public const ATTRIBUTE_NAME_A_NAME = 'name';
 
     /**
      * Removes all instances of replacements from target

--- a/tests/fixtures/vue-bind/bindings-with-encoded-attributes.twig
+++ b/tests/fixtures/vue-bind/bindings-with-encoded-attributes.twig
@@ -1,0 +1,12 @@
+<div class="{{class|default('')}}">
+  <a href="{{isBool ? varA.url : varB.url}}">
+    <img src="{{isBool ? varA.src : varB.src}}" alt="{{isBool ? varA.alt : varB.alt}}">
+  </a>
+  <form method="get" action="{{isBool ? varA.url : varB.url}}">
+    <label>
+      <input type="text" name="{{isBool ? varA.name : varB.name}}">
+    </label>
+    <input type="submit">
+  </form>
+  <a name="{{isBool ? varA.anchor : varB.anchor}}"></a>
+</div>

--- a/tests/fixtures/vue-bind/bindings-with-encoded-attributes.vue
+++ b/tests/fixtures/vue-bind/bindings-with-encoded-attributes.vue
@@ -1,0 +1,14 @@
+<template>
+  <div>
+    <a :href="isBool ? varA.url : varB.url">
+      <img :src="isBool ? varA.src : varB.src" :alt="isBool ? varA.alt : varB.alt">
+    </a>
+    <form :action="isBool ? varA.url : varB.url" method="get">
+      <label>
+        <input type="text" :name="isBool ? varA.name : varB.name">
+      </label>
+      <input type="submit">
+    </form>
+    <a :name="isBool ? varA.anchor : varB.anchor"/>
+  </div>
+</template>


### PR DESCRIPTION
The src attribute name is already fixed, but **href**, **action** and **name** has the same problem.

At this attributes the libxml2 will encode the value. 

See: https://gitlab.gnome.org/GNOME/libxml2/-/blob/LIBXML2.6.32/HTMLtree.c#L657

This will solves the problem.