### PR TITLE
Adds partially concat support

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ export default {
 <div style="{{ 'fontSize: ' ~ (size + 10) ~ 'px' }};"></div>
 ```
 
-But this example doesn't work:
+But this example doesn't work correct:
 
 ```vue
 <template>

--- a/README.md
+++ b/README.md
@@ -37,3 +37,51 @@ Compile vue files to twig templates with PHP
 ## Limitations
 
 It's difficult to interpret JavaScript language features and translate them into twig.
+
+For example, string concatenation within attribute binding is not currently working properly: :no_entry_sign:
+
+This example works:
+
+```vue
+<template>
+    <div :style="'fontSize: ' + (size + 10) + 'px'"></div> 
+</template>
+
+<script>
+export default {
+  props: {
+    size: {
+      type: number,
+      required: true,
+    },
+  },
+};
+</script>
+```
+
+```twig
+<div style="{{ 'fontSize: ' ~ (size + 10) ~ 'px' }};"></div>
+```
+
+But this example doesn't work:
+
+```vue
+<template>
+    <div :style="'fontSize: ' + (foo.size + 10) + 'px'"></div> 
+</template>
+
+<script>
+export default {
+  props: {
+    foo: {
+      type: object,
+      required: true,
+    },
+  },
+};
+</script>
+```
+
+```twig
+<div style="{{ 'fontSize: ' ~ (foo.size ~ 10) ~ 'px' }};"></div>
+```

--- a/README.md
+++ b/README.md
@@ -37,22 +37,3 @@ Compile vue files to twig templates with PHP
 ## Limitations
 
 It's difficult to interpret JavaScript language features and translate them into twig.
-
-For example string concatenation inside attribute binding does not work currently: :no_entry_sign:
-
-```vue
-<div :style="'fontSize: ' + size + 'px'"></div> 
-```
-
-But if you move this into a single property like (A) or (B), it will work.
-
-```vue
-<!-- (A) -->
-<div :style="divStyleProperty"></div> 
-
-<!-- (B) -->
-<div :style="{ fontSize: fontSizeVariable }"></div> 
-
-<!-- (C) -->
-<div :style="`fontSize: ${size}px`"></div>
-```

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ It's difficult to interpret JavaScript language features and translate them into
 For example string concatenation inside attribute binding does not work currently: :no_entry_sign:
 
 ```vue
-<div :style="{ fontSize: size + 'px' }"></div> 
+<div :style="'fontSize: ' + size + 'px'"></div> 
 ```
 
 But if you move this into a single property like (A) or (B), it will work.
@@ -52,4 +52,7 @@ But if you move this into a single property like (A) or (B), it will work.
 
 <!-- (B) -->
 <div :style="{ fontSize: fontSizeVariable }"></div> 
+
+<!-- (C) -->
+<div :style="`fontSize: ${size}px`"></div>
 ```

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -158,7 +158,7 @@ class Compiler
         $html = preg_replace('/<template>\s*(.*)\s*<\/template>/ism', '$1', $html);
         $html = preg_replace('/<\/?template[^>]*?>/i', '', $html);
 
-        $html = $this->builder->concatConvert($html, $this->properties);
+        $html = $this->builder->concatConvertHandler($html, $this->properties);
 
         if ($this->stripWhitespace) {
             $html = $this->stripWhitespace($html);

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -158,6 +158,8 @@ class Compiler
         $html = preg_replace('/<template>\s*(.*)\s*<\/template>/ism', '$1', $html);
         $html = preg_replace('/<\/?template[^>]*?>/i', '', $html);
 
+        $html = $this->builder->concatConvert($html, $this->properties);
+
         if ($this->stripWhitespace) {
             $html = $this->stripWhitespace($html);
         }
@@ -349,6 +351,10 @@ class Compiler
                     $property->setIsRequired(true);
                 }
 
+                if (preg_match('/type:\s*([a-z]+)/m', $definition, $matchType)) {
+                    $property->setType($matchType[1]);
+                }
+
                 if (preg_match('/default:\s*(?<default>[^,$]+)\s*,?/mx', $definition, $matchDefault)) {
                     $property->setDefault(trim($matchDefault['default']));
                 }
@@ -357,13 +363,16 @@ class Compiler
             }
         }
 
-        $typeScriptRegexProps = '/\@Prop\(.*?default\s*\:\s*(?<defaultValue>\'(?:[^\n](?!(?<![\\\\])\'))*.?\'|"(?:[^\n](?!(?<![\\\\])"))*.?"|[a-zA-Z0-9_]+).*?\)[^;]*?(?<propName>[a-zA-Z0-9_$]+)\!?\:[^;\@]*;/msx';
-
+        $typeScriptRegexProps = '/\@Prop\s*\({(?<propOptions>.*?)}\)[^;]*?(?<propName>[a-zA-Z0-9_$]+)\!?\:\s*(?<propType>[a-zA-Z]+)[^;\@]*;/msx';
+        $typeScriptRegexDefault = '/default\s*\:\s*(?<defaultValue>\'(?:.(?!(?<![\\\\])\'))*.?\'|"(?:.(?!(?<![\\\\])"))*.?"|[a-zA-Z0-9_]+)/msx';
         if (preg_match_all($typeScriptRegexProps, $content, $typeScriptMatches, PREG_SET_ORDER)) {
             $this->properties = [];
             foreach ($typeScriptMatches as $typeScriptMatch) {
                 $property = new Property($typeScriptMatch['propName'], '', true);
-                $property->setDefault(trim($typeScriptMatch['defaultValue']));
+                if (preg_match($typeScriptRegexDefault, $typeScriptMatch['propOptions'], $defaultMatch)) {
+                    $property->setDefault(trim($defaultMatch['defaultValue']));
+                }
+                $property->setType(trim($typeScriptMatch['propType']));
                 $this->properties[$typeScriptMatch['propName']] = $property;
             }
         }

--- a/src/Models/Concat.php
+++ b/src/Models/Concat.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paneon\VueToTwig\Models;
+
+use Exception;
+use Ramsey\Uuid\Uuid;
+
+class Concat
+{
+    public const CONCAT_REGEX = '/__CONCAT_[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}__/';
+
+    /**
+     * @var string
+     */
+    protected $uuid;
+
+    /**
+     * @var string
+     */
+    protected $value;
+
+    /**
+     * @var bool
+     */
+    protected $isNumeric;
+
+    /**
+     * Slot constructor.
+     *
+     * @throws Exception
+     */
+    public function __construct(string $value, bool $isNumeric)
+    {
+        $this->uuid = Uuid::uuid4()->toString();
+        $this->value = $value;
+        $this->isNumeric = $isNumeric;
+    }
+
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+
+    public function setValue(string $value): void
+    {
+        $this->value = $value;
+    }
+
+    public function isNumeric(): bool
+    {
+        return $this->isNumeric;
+    }
+
+    public function setIsNumeric(bool $isNumeric): void
+    {
+        $this->isNumeric = $isNumeric;
+    }
+
+    public function getConcatContentVariableString(): string
+    {
+        return '__CONCAT_' . $this->uuid . '__';
+    }
+
+    public function getUuid(): string
+    {
+        return $this->uuid;
+    }
+}

--- a/src/Models/Concat.php
+++ b/src/Models/Concat.php
@@ -9,7 +9,7 @@ use Ramsey\Uuid\Uuid;
 
 class Concat
 {
-    public const CONCAT_REGEX = '/__CONCAT_[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}__/';
+    public const CONCAT_REGEX = '/__CONCAT_[a-f0-9]{8}_[a-f0-9]{4}_[a-f0-9]{4}_[a-f0-9]{4}_[a-f0-9]{12}__/';
 
     /**
      * @var string
@@ -60,7 +60,7 @@ class Concat
 
     public function getConcatContentVariableString(): string
     {
-        return '__CONCAT_' . $this->uuid . '__';
+        return '__CONCAT_' . str_replace('-', '_', $this->uuid) . '__';
     }
 
     public function getUuid(): string

--- a/src/Models/Property.php
+++ b/src/Models/Property.php
@@ -32,6 +32,11 @@ class Property
     protected $default;
 
     /**
+     * @var string|null
+     */
+    protected $type;
+
+    /**
      * Property constructor.
      */
     public function __construct(string $name, string $value, bool $isBinding)
@@ -84,5 +89,15 @@ class Property
     public function setDefault(string $default): void
     {
         $this->default = $default;
+    }
+
+    public function getType(): ?string
+    {
+        return $this->type;
+    }
+
+    public function setType(?string $type): void
+    {
+        $this->type = $type;
     }
 }

--- a/src/Utils/TwigBuilder.php
+++ b/src/Utils/TwigBuilder.php
@@ -302,21 +302,32 @@ class TwigBuilder
     /**
      * @param Property[] $properties
      */
-    public function concatConvert(string $content, array $properties): string
+    public function concatConvertHandler(string $content, array $properties): string
     {
         preg_match_all('/{{(.*?)}}/sm', $content, $matches);
         foreach ($matches[1] as $match) {
-            $parts = explode('+', $match);
-            $numericConcat = true;
-            foreach ($parts as $key => $part) {
-                $numericConcat = $numericConcat && $this->isNumeric($part, $properties);
-            }
             $content = str_replace(
                 '{{' . $match . '}}',
-                '{{' . implode($numericConcat ? '+' : '~', $parts) . '}}',
+                '{{' . $this->concatConvert($match, $properties) . '}}',
                 $content
             );
         }
+
+        return $content;
+    }
+
+    /**
+     * @param Property[] $properties
+     */
+    public function concatConvert(string $content, array $properties): string
+    {
+        $parts = explode('+', $content);
+        $numericConcat = true;
+        foreach ($parts as $key => $part) {
+            $numericConcat = $numericConcat && $this->isNumeric($part, $properties);
+        }
+
+        $content = implode($numericConcat ? '+' : '~', $parts);
 
         return $content;
     }

--- a/src/Utils/TwigBuilder.php
+++ b/src/Utils/TwigBuilder.php
@@ -413,7 +413,7 @@ class TwigBuilder
             return $this->concat[$value]->isNumeric();
         }
 
-        $mathematicsParts = preg_split('/[-\*\/%]+/', $value);
+        $mathematicsParts = preg_split('/[-*\/%]+/', $value);
         if (count($mathematicsParts) > 1) {
             $isNumeric = true;
             foreach ($mathematicsParts as $mathematicsPart) {

--- a/src/Utils/TwigBuilder.php
+++ b/src/Utils/TwigBuilder.php
@@ -307,20 +307,15 @@ class TwigBuilder
         preg_match_all('/{{(.*?)}}/sm', $content, $matches);
         foreach ($matches[1] as $match) {
             $parts = explode('+', $match);
-            $newOutput = '';
-            $lastOperand = null;
+            $numericConcat = true;
             foreach ($parts as $key => $part) {
-                if ($key > 0) {
-                    if ($lastOperand && $this->isNumeric($part, $properties)) {
-                        $newOutput .= '+';
-                    } else {
-                        $newOutput .= '~';
-                    }
-                }
-                $newOutput .= $part;
-                $lastOperand = $this->isNumeric($part, $properties);
+                $numericConcat = $numericConcat && $this->isNumeric($part, $properties);
             }
-            $content = str_replace('{{' . $match . '}}', '{{' . $newOutput . '}}', $content);
+            $content = str_replace(
+                '{{' . $match . '}}',
+                '{{' . implode($numericConcat ? '+' : '~', $parts) . '}}',
+                $content
+            );
         }
 
         return $content;

--- a/src/Utils/TwigBuilder.php
+++ b/src/Utils/TwigBuilder.php
@@ -413,6 +413,16 @@ class TwigBuilder
             return $this->concat[$value]->isNumeric();
         }
 
+        $subParts = preg_split('/[-\*\/%]+/', $value);
+        if (count($subParts) > 1) {
+            $isNumeric = true;
+            foreach ($subParts as $subPart) {
+                $isNumeric = $isNumeric && $this->isNumeric($subPart, $properties);
+            }
+
+            return $isNumeric;
+        }
+
         return is_numeric($value);
     }
 }

--- a/src/Utils/TwigBuilder.php
+++ b/src/Utils/TwigBuilder.php
@@ -338,8 +338,8 @@ class TwigBuilder
                 );
             }
 
-            $data = $this->replaceConcatCharacter($outputTerm, $properties);
-            $newOutputTerm = $data['value'] ?? '';
+            $concat = $this->replaceConcatCharacter($outputTerm, $properties);
+            $newOutputTerm = $concat->getValue() ?? '';
 
             while (preg_match_all(Concat::CONCAT_REGEX, $newOutputTerm, $chambersTerms)) {
                 foreach ($chambersTerms[0] as $chambersTerm) {
@@ -366,12 +366,9 @@ class TwigBuilder
      */
     private function convertConcat(string $content, array $properties): string
     {
-        $data = $this->replaceConcatCharacter($content, $properties);
+        $concat = $this->replaceConcatCharacter($content, $properties);
 
-        $concat = new Concat(
-            '(' . $data['value'] . ')',
-            $data['isNumeric']
-        );
+        $concat->setValue('(' . $concat->getValue() . ')');
 
         $concatId = $concat->getConcatContentVariableString();
         $this->concat[$concatId] = $concat;
@@ -382,9 +379,9 @@ class TwigBuilder
     /**
      * @param Property[] $properties
      *
-     * @return mixed[]
+     * @throws Exception
      */
-    private function replaceConcatCharacter(string $content, array $properties): array
+    private function replaceConcatCharacter(string $content, array $properties): Concat
     {
         $parts = explode('+', $content);
         $isNumericConcat = true;
@@ -393,10 +390,10 @@ class TwigBuilder
             $isNumericConcat = $isNumericConcat && $this->isNumeric($part, $properties);
         }
 
-        return [
-            'value' => implode($isNumericConcat ? '+' : '~', $parts),
-            'isNumeric' => $isNumericConcat,
-        ];
+        return new Concat(
+            implode($isNumericConcat ? '+' : '~', $parts),
+            $isNumericConcat
+        );
     }
 
     /**

--- a/src/Utils/TwigBuilder.php
+++ b/src/Utils/TwigBuilder.php
@@ -413,11 +413,11 @@ class TwigBuilder
             return $this->concat[$value]->isNumeric();
         }
 
-        $subParts = preg_split('/[-\*\/%]+/', $value);
-        if (count($subParts) > 1) {
+        $mathematicsParts = preg_split('/[-\*\/%]+/', $value);
+        if (count($mathematicsParts) > 1) {
             $isNumeric = true;
-            foreach ($subParts as $subPart) {
-                $isNumeric = $isNumeric && $this->isNumeric($subPart, $properties);
+            foreach ($mathematicsParts as $mathematicsPart) {
+                $isNumeric = $isNumeric && $this->isNumeric($mathematicsPart, $properties);
             }
 
             return $isNumeric;

--- a/src/Utils/TwigBuilder.php
+++ b/src/Utils/TwigBuilder.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Paneon\VueToTwig\Utils;
 
+use Exception;
 use Paneon\VueToTwig\Models\Concat;
 use Paneon\VueToTwig\Models\Property;
 use Paneon\VueToTwig\Models\Replacements;
-use Exception;
 use ReflectionException;
 
 class TwigBuilder
@@ -368,6 +368,8 @@ class TwigBuilder
 
     /**
      * @param Property[] $properties
+     *
+     * @return mixed[]
      */
     private function replaceConcatCharacter(string $content, array $properties): array
     {

--- a/tests/ConcatTest.php
+++ b/tests/ConcatTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Paneon\VueToTwig\Tests;
+
+use Exception;
+
+class ConcatTest extends AbstractTestCase
+{
+    /**
+     * @dataProvider dataProvider
+     *
+     * @param mixed $html
+     * @param mixed $expected
+     *
+     * @throws Exception
+     */
+    public function testConcat($html, $expected)
+    {
+        $compiler = $this->createCompiler($html);
+
+        $actual = $compiler->convert();
+
+        $this->assertEqualHtml($expected, $actual);
+    }
+
+    /**
+     * @return array
+     */
+    public function dataProvider()
+    {
+        return $this->loadFixturesFromDir('concat');
+    }
+}

--- a/tests/fixtures/concat/concat-typescript.twig
+++ b/tests/fixtures/concat/concat-typescript.twig
@@ -1,0 +1,9 @@
+<div class="{{ class|default('') }}" style="{{ style|default('') }}">
+  <div style="{{ 'fontSize: ' ~ size ~ 'px' }};"></div>
+  <div>{{'foo' ~ ' bar'}}</div>
+  <div>{{text ~ ' foo'}}</div>
+  <div>{{text ~ 1}}</div>
+  <div>{{size ~ ' foo'}}</div>
+  <div>{{size + 1}}</div>
+  <div>{{1 + 1}}</div>
+</div>

--- a/tests/fixtures/concat/concat-typescript.vue
+++ b/tests/fixtures/concat/concat-typescript.vue
@@ -1,0 +1,23 @@
+<template>
+  <div>
+    <div :style="'fontSize: ' + size + 'px'"></div>
+    <div v-text="'foo' + ' bar'"></div>
+    <div v-text="text + ' foo'"></div>
+    <div v-text="text + 1"></div>
+    <div v-text="size + ' foo'"></div>
+    <div v-text="size + 1"></div>
+    <div v-text="1 + 1"></div>
+  </div>
+</template>
+
+<script lang="ts">
+  import { Component, Prop, Vue } from 'vue-property-decorator';
+
+  @Component
+  export default class PropsExample extends Vue {
+    @Prop({ type: String, required: true }) text: string;
+    @Prop({ type: Number, required: true }) size: number;
+  }
+</script>
+
+

--- a/tests/fixtures/concat/concat.twig
+++ b/tests/fixtures/concat/concat.twig
@@ -6,4 +6,6 @@
   <div>{{size ~ ' foo'}}</div>
   <div>{{size + 1}}</div>
   <div>{{1 + 1}}</div>
+  <div>{{'foo ' ~ size ~ size ~ ' bar'}}</div>
+  <div>{{'foo ' ~ ( size + size ) ~ ' bar'}}</div>
 </div>

--- a/tests/fixtures/concat/concat.twig
+++ b/tests/fixtures/concat/concat.twig
@@ -8,4 +8,7 @@
   <div>{{1 + 1}}</div>
   <div>{{'foo ' ~ size ~ size ~ ' bar'}}</div>
   <div>{{'foo ' ~ ( size + size ) ~ ' bar'}}</div>
+  <div>{{'foo ' ~ ( 1 + size ) ~ ' bar'}}</div>
+  <div>{{1 ~ ( 'foo' ~ size ) ~ 2}}</div>
+  <div>{{'foo ' ~ ( ( 1 + 2 ) ~ ( ' bar ' ~ ' baz ' ) ~ ( ' waz ' ~ 3 ) )}}</div>
 </div>

--- a/tests/fixtures/concat/concat.twig
+++ b/tests/fixtures/concat/concat.twig
@@ -16,4 +16,5 @@
   <div>{{( size * size ) / 2 + 10}}</div>
   <div>{{( size * size ) % 2 + 10}}</div>
   <div>{{( size - 10 ) * 2 + 10}}</div>
+  <div>{{'20 - 10 - 5' ~ 10}}</div>
 </div>

--- a/tests/fixtures/concat/concat.twig
+++ b/tests/fixtures/concat/concat.twig
@@ -11,4 +11,9 @@
   <div>{{'foo ' ~ ( 1 + size ) ~ ' bar'}}</div>
   <div>{{1 ~ ( 'foo' ~ size ) ~ 2}}</div>
   <div>{{'foo ' ~ ( ( 1 + 2 ) ~ ( ' bar ' ~ ' baz ' ) ~ ( ' waz ' ~ 3 ) )}}</div>
+  <div>{{'foo ' ~ ( size * size ) ~ ' bar'}}</div>
+  <div>{{( size * size ) + 2}}</div>
+  <div>{{( size * size ) / 2 + 10}}</div>
+  <div>{{( size * size ) % 2 + 10}}</div>
+  <div>{{( size - 10 ) * 2 + 10}}</div>
 </div>

--- a/tests/fixtures/concat/concat.twig
+++ b/tests/fixtures/concat/concat.twig
@@ -1,0 +1,9 @@
+<div class="{{ class|default('') }}" style="{{ style|default('') }}">
+  <div style="{{ 'fontSize: ' ~ size ~ 'px' }};"></div>
+  <div>{{'foo' ~ ' bar'}}</div>
+  <div>{{text ~ ' foo'}}</div>
+  <div>{{text ~ 1}}</div>
+  <div>{{size ~ ' foo'}}</div>
+  <div>{{size + 1}}</div>
+  <div>{{1 + 1}}</div>
+</div>

--- a/tests/fixtures/concat/concat.vue
+++ b/tests/fixtures/concat/concat.vue
@@ -9,7 +9,9 @@
     <div v-text="1 + 1"></div>
     <div v-text="'foo ' + size + size + ' bar'"></div>
     <div v-text="'foo ' + ( size + size ) + ' bar'"></div>
-
+    <div v-text="'foo ' + ( 1 + size ) + ' bar'"></div>
+    <div v-text="1 + ( 'foo' + size ) + 2"></div>
+    <div v-text="'foo ' + ( ( 1 + 2 ) + ( ' bar ' + ' baz ' ) + ( ' waz ' + 3 ) )"></div>
   </div>
 </template>
 

--- a/tests/fixtures/concat/concat.vue
+++ b/tests/fixtures/concat/concat.vue
@@ -17,6 +17,7 @@
     <div v-text="( size * size ) / 2 + 10"></div>
     <div v-text="( size * size ) % 2 + 10"></div>
     <div v-text="( size - 10 ) * 2 + 10"></div>
+    <div v-text="'20 - 10 - 5' + 10"></div>
   </div>
 </template>
 

--- a/tests/fixtures/concat/concat.vue
+++ b/tests/fixtures/concat/concat.vue
@@ -1,0 +1,26 @@
+<template>
+  <div>
+    <div :style="'fontSize: ' + size + 'px'"></div>
+    <div v-text="'foo' + ' bar'"></div>
+    <div v-text="text + ' foo'"></div>
+    <div v-text="text + 1"></div>
+    <div v-text="size + ' foo'"></div>
+    <div v-text="size + 1"></div>
+    <div v-text="1 + 1"></div>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    text: {
+      type: string,
+      required: true,
+    },
+    size: {
+      type: number,
+      required: true,
+    },
+  },
+};
+</script>

--- a/tests/fixtures/concat/concat.vue
+++ b/tests/fixtures/concat/concat.vue
@@ -7,6 +7,9 @@
     <div v-text="size + ' foo'"></div>
     <div v-text="size + 1"></div>
     <div v-text="1 + 1"></div>
+    <div v-text="'foo ' + size + size + ' bar'"></div>
+    <div v-text="'foo ' + ( size + size ) + ' bar'"></div>
+
   </div>
 </template>
 

--- a/tests/fixtures/concat/concat.vue
+++ b/tests/fixtures/concat/concat.vue
@@ -12,6 +12,11 @@
     <div v-text="'foo ' + ( 1 + size ) + ' bar'"></div>
     <div v-text="1 + ( 'foo' + size ) + 2"></div>
     <div v-text="'foo ' + ( ( 1 + 2 ) + ( ' bar ' + ' baz ' ) + ( ' waz ' + 3 ) )"></div>
+    <div v-text="'foo ' + ( size * size ) + ' bar'"></div>
+    <div v-text="( size * size ) + 2"></div>
+    <div v-text="( size * size ) / 2 + 10"></div>
+    <div v-text="( size * size ) % 2 + 10"></div>
+    <div v-text="( size - 10 ) * 2 + 10"></div>
   </div>
 </template>
 

--- a/tests/fixtures/vue-bind/binding-with-template-string-2.twig
+++ b/tests/fixtures/vue-bind/binding-with-template-string-2.twig
@@ -1,4 +1,5 @@
 <div class="block {{ class|default('') }}" style="{{ style|default('') }}">
+  <div style="fontSize: {{ size }}px;"></div>
   <div class="block block--{{ modifier }}" style="fill: {{ color }}; height: {{ height }};">
     Hello World
   </div>

--- a/tests/fixtures/vue-bind/binding-with-template-string-2.vue
+++ b/tests/fixtures/vue-bind/binding-with-template-string-2.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="block">
+    <div :style="`fontSize: ${size}px`"></div>
     <div :class="`block block--${modifier}`" :style="`fill: ${color}; height: ${height}`">
       Hello World
     </div>


### PR DESCRIPTION
This example works:

```vue
<template>
    <div :style="'fontSize: ' + (size + 10) + 'px'"></div> 
</template>

<script>
export default {
  props: {
    size: {
      type: number,
      required: true,
    },
  },
};
</script>
```

```twig
<div style="{{ 'fontSize: ' ~ (size + 10) ~ 'px' }};"></div>
```

But this example doesn't work correct:

```vue
<template>
    <div :style="'fontSize: ' + (foo.size + 10) + 'px'"></div> 
</template>

<script>
export default {
  props: {
    foo: {
      type: object,
      required: true,
    },
  },
};
</script>
```

```twig
<div style="{{ 'fontSize: ' ~ (foo.size ~ 10) ~ 'px' }};"></div>
```