### PR TITLE
Fixed #73 add error handling for scss compiler

### DIFF
--- a/src/Utils/StyleBuilder.php
+++ b/src/Utils/StyleBuilder.php
@@ -7,6 +7,7 @@ namespace Paneon\VueToTwig\Utils;
 use DOMElement;
 use Exception;
 use ScssPhp\ScssPhp\Compiler as ScssCompiler;
+use ScssPhp\ScssPhp\Exception\CompilerException;
 
 class StyleBuilder
 {
@@ -83,7 +84,11 @@ class StyleBuilder
             if ($this->scssCompiler === null) {
                 $this->scssCompiler = new ScssCompiler();
             }
-            $style = $this->scssCompiler->compile($this->scssData . ' ' . $style);
+            try {
+                $style = $this->scssCompiler->compile($this->scssData . ' ' . $style);
+            } catch (CompilerException $e) {
+                $style = "\n/* Warning: " . $e->getMessage() . " */\n";
+            }
         }
 
         if ($styleElement->hasAttribute('scoped')) {

--- a/tests/fixtures/style-block/style-block-scss-error-handling.twig
+++ b/tests/fixtures/style-block/style-block-scss-error-handling.twig
@@ -1,0 +1,6 @@
+<style>/* Warning: `./file` file not found for @import: line: 2, column: 1 */</style>
+<div class="{{ class|default('') }}" style="{{ style|default('') }}">
+    <div class="foo">
+      foo
+    </div>
+</div>

--- a/tests/fixtures/style-block/style-block-scss-error-handling.vue
+++ b/tests/fixtures/style-block/style-block-scss-error-handling.vue
@@ -1,0 +1,26 @@
+<template>
+<div>
+  <div class="foo">
+    foo
+  </div>
+</div>
+</template>
+
+<style lang="scss">
+@import "./file";
+
+.foo {
+  color: red;
+  &__bar {
+    color: blue;
+  }
+  &__baz {
+    color: $color;
+  }
+}
+</style>
+
+<script>
+    export default {
+    }
+</script>


### PR DESCRIPTION
If the scss compiler throws an error, the Twig file will still be created.
